### PR TITLE
Add watch script and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ cd walleon
 npm install --prefix client && npm install --prefix server
 ```
 
-### Compiles and hot-reloads for development
+### Compiles for development and watches client files for changes
 ```
-npm run serve --prefix client
+npm run watch --prefix client
 npm run build --prefix server && npm start --prefix server
 ```
+
+Vue CLI can serve and hot-reload with `npm run serve --prefix client` but won't work with our backend. Use `npm run watch --prefix client` and manually refresh page in browser.
 
 ### Compiles and minifies for production
 ```

--- a/walleon/client/package.json
+++ b/walleon/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
+    "watch": "vue-cli-service build --watch",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/walleon/server/src/middleware/serve.js
+++ b/walleon/server/src/middleware/serve.js
@@ -3,9 +3,9 @@ import serve from "koa-static";
 import path from "path";
 
 export const serveViews = () => {
-  return views(path.join(__dirname, "/../public"), {});
+  return views(path.join(__dirname, "/../../../client/dist"), {});
 };
 
 export const serveStatic = () => {
-  return serve(path.join(__dirname, "/../public"), {});
+  return serve(path.join(__dirname, "/../../../client/dist"), {});
 };

--- a/walleon/server/src/middleware/serve.js
+++ b/walleon/server/src/middleware/serve.js
@@ -3,9 +3,9 @@ import serve from "koa-static";
 import path from "path";
 
 export const serveViews = () => {
-  return views(path.join(__dirname, "/../../../client/dist"), {});
+  return views(path.join(__dirname, "/../public"), {});
 };
 
 export const serveStatic = () => {
-  return serve(path.join(__dirname, "/../../../client/dist"), {});
+  return serve(path.join(__dirname, "/../public"), {});
 };


### PR DESCRIPTION
Vue CLI kör egen server när man kör npm run serve som krockar med vår server. Så nu kör vi istället att Vue CLI endast lyssnar efter ändringar på client filerna.